### PR TITLE
解决卡片每次显示都会先闪一下没样式的内容

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -21,6 +21,12 @@
         padding: 15px;
       }
     }
+	
+	/* 初始状态下设置透明度为0 */
+	  .md-content {
+		opacity: 0;
+		transition: opacity 0.3s ease-in-out;
+	  }
   </style>
   <body>
     <br />\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}\]<br />


### PR DESCRIPTION
在win端和安卓端都出现了卡片显示前会闪一下没有样式的卡片内容，问题和答案都出现了。
调整：在卡片的样式处增加改动代码。